### PR TITLE
Update README to explain usage with HTML formatter (and other minor changes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add `tailwind_formatter` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:tailwind_formatter, "~> 0.3"}
+    {:tailwind_formatter, "~> 0.3", only: :dev, runtime: false}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@
 
 <!-- MDOC !-->
 
-Enforce a `class` attribute order within markup using [TailwindCSS](tailwindcss.com). 
+Opinionated sorting for [TailwindCSS](https://tailwindcss.com)
+classes used in HEEx templates and `~H` sigils.
 
-this is a `mix format` [plugin](https://hexdocs.pm/mix/main/Mix.Tasks.Format.html#module-plugins).
+`TailwindFormatter` is a `mix format` [plugin](https://hexdocs.pm/mix/main/Mix.Tasks.Format.html#module-plugins)
+that sorts TailwindCSS classes found in your templates. It takes
+inspiration from Tailwind's official [Prettier plugin](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier).
 
-> Note: The Tailwind Formatter requires Elixir v1.13.4 or later
+> Note: This formatter requires Elixir v1.13.4 or later.
 
 ## Installation
 
@@ -17,73 +20,89 @@ Add `tailwind_formatter` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:tailwind_formatter, "~> 0.3.0"}
-
-    # alternatively, keep track with the latest release:
-    {:tailwind_formatter, github: "100phlecs/tailwind_formatter"}
+    {:tailwind_formatter, "~> 0.3"}
   ]
 end
 ```
 
 ## Setup
 
-Add it as a plugin to your project's `.formatter.exs`. 
-Make sure to put in the `heex` extension to the possible inputs.
+`TailwindFormatter` is most likely to be used alongside `Phoenix.LiveView.HTMLFormatter`,
+so it should be installed in a way that allows the HTML formatter to
+run first, followed by the Tailwind formatter. How this is done
+depends on your version of Elixir.
+
+### Setup for Elixir v1.15.0-dev
+
+Elixir v1.15 [will support](https://github.com/elixir-lang/elixir/pull/12032)
+applying multiple plugins to the same file extension type, so the
+plugin can be added after the HTML formatter in your `.formatter.exs`:
+
+```elixir
+[
+  plugins: [Phoenix.LiveView.HTMLFormatter, TailwindFormatter],
+  inputs: [
+    "*.{heex,ex,exs}",
+    "priv/*/seeds.exs",
+    "{config,lib,test}/**/*.{heex,ex,exs}"
+  ],
+  # ...
+]
+```
+
+### Setup for Elixir v1.13.4 and v1.14
+
+Current stable versions of Elixir do not support applying multiple
+formatter plugins to the same extension type. To overcome this,
+a `MultiFormatter` is provided that is equivalent to running the
+`Phoenix.LiveView.HTMLFormatter` first, followed by `TailwindFormatter`.
+
+```elixir
+  [
+    plugins: [MultiFormatter],
+    inputs: [
+      "*.{heex,ex,exs}",
+      "priv/*/seeds.exs",
+      "{config,lib,test}/**/*.{heex,ex,exs}"
+    ],
+    # ...
+  ]
+```
+
+If you only want Tailwind class organization and not HTML formatting,
+you can simply specify only the `TailwindFormatter`:
 
 ```elixir
   [
     plugins: [TailwindFormatter],
     inputs: [
-    "*.{heex,ex,exs}",
-    "{config,lib,test}/**/*.{heex,ex,exs}"
+      "*.{heex,ex,exs}",
+      "priv/*/seeds.exs",
+      "{config,lib,test}/**/*.{heex,ex,exs}"
     ],
+    # ...
   ]
 ```
 
-Then run `mix deps.get` and also `mix compile` to load in the plugin.
+## Usage
 
-After that, run the formatter with `mix format`.
+After installation and setup, run `mix format`. If you already had
+automatic formatting set up (for instance, if your editor is configured
+to format your code on save), no changes should be required! Your
+Tailwind classes should be happily organized going forward!
 
-Note: If you're using multiple formatters and you're running an Elixir
-version that supports multiple format plugins, keep in mind that the
-order by which the plugins are defined in the `plugins: []` array are
-the order in which they are ran.
-
-### Setup multiple formatters for older versions 
-
-If you plan to use this with another formatter, you may run into issues.
-Thie is because `mix format`, depending on your version, may not support multiple
-plugins ([just yet](https://github.com/elixir-lang/elixir/pull/12032))!
-
-There are two options to work around this. The first option is, if you
-are formatting with `Phoenix.LiveView.HTMLFormatter`, to use the
-`MultiFormatter` shipped with this library instead of
-`TailwindFormatter`.
-
-The `MultiFormatter` will first format with `HTMLFormatter` and then
-follow up with `TailwindFormatter`.
-
-The other option is to set up two `.formatter.exs` files and a script
-within your base directory, i.e. `format.sh` which runs both.
-
-In `format.sh`:
-
-```bash
-#!/usr/bin/env bash
-mix format --dot-formatter .tailwind_formatter.exs
-mix format # this runs the default .formatter.exs
-```
-
-And then `chmod +x format.sh`.
+If some files are not being formatted as expected, double-check the
+`:inputs` option in your `.formatter.exs` to ensure they are being
+matched.
 
 ## Formatting
 
 The formatter aims to follow a bundle of rules outlined in the [blog post](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier)
-that introduces the official Tailwind sorter plugin. 
+that introduced the official Tailwind Prettier plugin.
 
-- Order them the same way classes are imported in the CSS file. Base, Components, Utilities.
+- Order classes the same way they are imported in the CSS file: Base, Components, Utilities
 - Classes that override other classes appear later in the list
-- Classes that impact layout take precedence over classes that decorate 
+- Classes that impact layout take precedence over classes that decorate
 - Plain classes come first before variants (i.e. `focus:`)
 - Unknown classes are sorted to the front
 
@@ -98,15 +117,15 @@ The formatter supports this and sorts these toward the front.
 
 ### Variants are always grouped, even if the class is unknown
 
-i.e. `sm:unknown-class` will still be grouped with the other `sm:` variants, even if Tailwind doesn't recognize the class. 
+i.e. `sm:unknown-class` will still be grouped with the other `sm:` variants, even if Tailwind doesn't recognize the class.
 
-### Variant order is enforced 
+### Variant order is enforced
 
-In the original spec, 'variants' i.e. `sm:hover:` are sorted as though it is one block. 
+In the original spec, 'variants' i.e. `sm:hover:` are sorted as though it is one block.
 Thus, the order in which they're specified does not matter.
-So, for example, a chain of `dark:sm:hover:text-gray-600` would be placed toward the end. 
+So, for example, a chain of `dark:sm:hover:text-gray-600` would be placed toward the end.
 
-In this algorithm, classes are sorted by "layers". 
+In this algorithm, classes are sorted by "layers".
 All `sm:` variants are grouped together, even if it's a chain of 4 variants.
 So for example, `dark:sm:hover:text-gray-600` will be placed before any `sm:` and `hover:` variants, because `dark:` has precedence over `sm:` and `hover:`.
 
@@ -124,6 +143,6 @@ As this is quite new there may be some Tailwind classes missing.
 
 ## Credits
 
-This project builds heavily off of [rustywind](https://github.com/avencera/rustywind) 
+This project builds heavily off of [rustywind](https://github.com/avencera/rustywind)
 and [HTMLFormatter](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.HTMLFormatter.html).
 


### PR DESCRIPTION
Hi there!

Just got this plugin installed following your [announcement](https://elixirforum.com/t/tailwindformatter-opinionated-tailwind-class-sorter-for-heex-templates/50410/3) on Elixir Forum! Great work -- I'm excited to not have to think about this stuff myself anymore 😄 

I had a bit of trouble following the README when I was first getting it set up. It didn't take long, but I thought I'd take a crack at re-writing the setup instructions to be more explicit about how it should be used with the Phoenix LiveView HTML Formatter depending on the version of Elixir you're running. While I was at it, I also did some minor copy editing that I think makes things more clear.

Please feel free to push to/edit this branch if you want to undo any of the changes I made. (Though I'm also happy to adjust things based on your feedback!)