### PR TITLE
Class interpolation / Dynamics classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,21 @@ So for example, `dark:sm:hover:text-gray-600` will be placed before any `sm:` an
 Thus in order to achieve more consistency, the variant chain is ordered.
 So, `dark:sm:hover:text-gray-600` transforms to `sm:dark:hover:text-gray-600`.
 
+
+### Dynamically rendered classes
+
+Sometimes you may want to dynamically render a class depending on a variable,
+i.e. `lg:grid-cols-#{@cols}` or `alert alert-#{@type}`.  The formatter supports
+this, and also sorts these toward the front of the variant group it is within.
+
+Note: you will need to define the full class either within the Tailwind
+[safelist](https://tailwindcss.com/docs/content-configuration#safelisting-classes)
+or have it fully written out somewhere else in the source file.
+
+So, for example, if `@cols = 5` within `grid-cols-#{@cols}`, then you will need
+`grid-cols-5` written in full somewhere in the source so Tailwind won't purge it
+in production.
+
 ## Custom classes
 
 As a bonus this plugin supports the [Phoenix variants](https://fly.io/phoenix-files/phoenix-liveview-tailwind-variants/)

--- a/lib/tailwind_formatter/defaults.ex
+++ b/lib/tailwind_formatter/defaults.ex
@@ -2,7 +2,9 @@ defmodule TailwindFormatter.Defaults do
   @moduledoc false
   @class_pattern ~r/(?:class\s*(?:=|:)[\s{]*)('|")(.|\s)*?\1}*(?=[^"]*?(=|>))/i
   @inline_func_pattern ~r/#\{([^}]+)\}*/i
-  @invalid_input ~r/[^_a-zA-Z0-9\s\-:\[\]]+/
+  @dynamic_classes ~r/[[:alnum:]-]*#\{([^}]+)\}*/i
+  @invalid_input ~r/[^_a-zA-Z0-9\$\s\-:\[\]\/\.\#]+/
+  @placeholders ~r/\$[0-9]+/i
 
   @variants "priv/variants.txt"
             |> File.read!()
@@ -30,6 +32,14 @@ defmodule TailwindFormatter.Defaults do
 
   def func_regex() do
     @inline_func_pattern
+  end
+
+  def dynamic_class_regex() do
+    @dynamic_classes
+  end
+
+  def placeholder_class_regex() do
+    @placeholders
   end
 
   def class_order() do

--- a/lib/tailwind_formatter/defaults.ex
+++ b/lib/tailwind_formatter/defaults.ex
@@ -1,10 +1,9 @@
 defmodule TailwindFormatter.Defaults do
   @moduledoc false
-  @class_pattern ~r/(?:class\s*(?:=|:)[\s{]*)('|")(.|\s)*?\1}*(?=[^"]*?(=|>))/i
+  @class_pattern ~r/(?:class\s*(?:=|:)[\s{]*)('|")(.|\s)*?\1}*/i
   @inline_func_pattern ~r/#\{([^}]+)\}*/i
   @dynamic_classes ~r/[[:alnum:]-]*#\{([^}]+)\}*/i
   @invalid_input ~r/[^_a-zA-Z0-9\$\s\-:\[\]\/\.\#]+/
-  @placeholders ~r/\$[0-9]+/i
 
   @variants "priv/variants.txt"
             |> File.read!()
@@ -36,10 +35,6 @@ defmodule TailwindFormatter.Defaults do
 
   def dynamic_class_regex() do
     @dynamic_classes
-  end
-
-  def placeholder_class_regex() do
-    @placeholders
   end
 
   def class_order() do

--- a/lib/tailwind_formatter/defaults.ex
+++ b/lib/tailwind_formatter/defaults.ex
@@ -1,7 +1,7 @@
 defmodule TailwindFormatter.Defaults do
   @moduledoc false
   @class_pattern ~r/(?:class\s*(?:=|:)[\s{]*)('|")(.|\s)*?\1}*(?=[^"]*?(=|>))/i
-  @inline_func_pattern ~r/#\{[^}]+\}*/i
+  @inline_func_pattern ~r/#\{([^}]+)\}*/i
   @invalid_input ~r/[^_a-zA-Z0-9\s\-:\[\]]+/
 
   @variants "priv/variants.txt"

--- a/test/tailwind_formatter_test.exs
+++ b/test/tailwind_formatter_test.exs
@@ -12,6 +12,12 @@ defmodule TailwindFormatterTest do
     assert second_pass == expected
   end
 
+  defp assert_formatter_raise(input, dot_formatter_opts \\ []) do
+    assert_raise ArgumentError, fn ->
+      TailwindFormatter.format(input, dot_formatter_opts)
+    end
+  end
+
   test "works" do
     input = """
     <div class="text-sm potato sm:lowercase uppercase"></div>
@@ -146,6 +152,42 @@ defmodule TailwindFormatterTest do
     assert_formatter_output(input, expected)
   end
 
+  test "decimal classes are sorted" do
+    input = """
+    <div class="text-sm potato unknown1 py-3.5 px-3.5 unknown2 sm:lowercase uppercase"></div>
+    """
+
+    expected = """
+    <div class="potato unknown1 unknown2 text-sm py-3.5 px-3.5 uppercase sm:lowercase"></div>
+    """
+
+    assert_formatter_output(input, expected)
+  end
+
+  test "classes with backslash are sorted" do
+    input = """
+    <div class="text-sm potato unknown1 -inset-1/2 unknown2 sm:lowercase uppercase"></div>
+    """
+
+    expected = """
+    <div class="potato unknown1 unknown2 -inset-1/2 text-sm uppercase sm:lowercase"></div>
+    """
+
+    assert_formatter_output(input, expected)
+  end
+
+  test "classes with hash are sorted" do
+    input = """
+    <div class="text-sm potato bg-[#333] unknown1 unknown2 sm:lowercase uppercase"></div>
+    """
+
+    expected = """
+    <div class="bg-[#333] potato unknown1 unknown2 text-sm uppercase sm:lowercase"></div>
+    """
+
+    assert_formatter_output(input, expected)
+  end
+
   test "keep consistent format order for unknown classes" do
     input = """
     <div class="text-sm potato unknown1 unknown2 sm:lowercase uppercase"></div>
@@ -242,13 +284,7 @@ defmodule TailwindFormatterTest do
         href="#"></a>
       """
 
-      expected = ~S"""
-      <a class={"#{if false, do: "bg-white" text-sm potato sm:lowercase uppercase"
-        id="testing
-        href="#"></a>
-      """
-
-      assert_formatter_output(input, expected)
+      assert_formatter_raise(input)
     end
 
     test "missing number tag inline elixir" do

--- a/test/tailwind_formatter_test.exs
+++ b/test/tailwind_formatter_test.exs
@@ -112,12 +112,12 @@ defmodule TailwindFormatterTest do
 
   test "regex allows multiple attributes" do
     input = ~S"""
-    <a id="testing" class={"#{if false, do: "bg-white"} text-sm potato sm:lowercase #{isready?(@check)} uppercase"}
+    <a id="testing" class={"#{if false, do: "bg-white"} grid-cols-#{@test} text-sm potato sm:lowercase #{isready?(@check)} uppercase"}
       href="#"></a>
     """
 
     expected = ~S"""
-    <a id="testing" class={"#{if false, do: "bg-white"} #{isready?(@check)} potato text-sm uppercase sm:lowercase"}
+    <a id="testing" class={"#{if false, do: "bg-white"} grid-cols-#{@test} #{isready?(@check)} potato text-sm uppercase sm:lowercase"}
       href="#"></a>
     """
 
@@ -158,7 +158,7 @@ defmodule TailwindFormatterTest do
     """
 
     expected = """
-    <div class="potato unknown1 unknown2 text-sm py-3.5 px-3.5 uppercase sm:lowercase"></div>
+    <div class="potato unknown1 unknown2 px-3.5 py-3.5 text-sm uppercase sm:lowercase"></div>
     """
 
     assert_formatter_output(input, expected)
@@ -182,7 +182,7 @@ defmodule TailwindFormatterTest do
     """
 
     expected = """
-    <div class="bg-[#333] potato unknown1 unknown2 text-sm uppercase sm:lowercase"></div>
+    <div class="potato bg-[#333] unknown1 unknown2 text-sm uppercase sm:lowercase"></div>
     """
 
     assert_formatter_output(input, expected)

--- a/test/tailwind_formatter_test.exs
+++ b/test/tailwind_formatter_test.exs
@@ -112,12 +112,40 @@ defmodule TailwindFormatterTest do
 
   test "regex allows multiple attributes" do
     input = ~S"""
-    <a id="testing" class={"#{if false, do: "bg-white"} grid-cols-#{@test} text-sm potato sm:lowercase #{isready?(@check)} uppercase"}
+    <a id="testing" class={"#{if false, do: "bg-white"} text-sm potato sm:lowercase #{isready?(@check)} uppercase"}
       href="#"></a>
     """
 
     expected = ~S"""
-    <a id="testing" class={"#{if false, do: "bg-white"} grid-cols-#{@test} #{isready?(@check)} potato text-sm uppercase sm:lowercase"}
+    <a id="testing" class={"#{if false, do: "bg-white"} #{isready?(@check)} potato text-sm uppercase sm:lowercase"}
+      href="#"></a>
+    """
+
+    assert_formatter_output(input, expected)
+  end
+
+  test "dynamic classes" do
+    input = ~S"""
+    <a id="testing" class={"  text-sm potato sm:lowercase   grid-cols-#{@test} uppercase"}
+      href="#"></a>
+    """
+
+    expected = ~S"""
+    <a id="testing" class={"grid-cols-#{@test} potato text-sm uppercase sm:lowercase"}
+      href="#"></a>
+    """
+
+    assert_formatter_output(input, expected)
+  end
+
+  test "dynamic varient classes" do
+    input = ~S"""
+    <a id="testing" class={"  text-sm potato sm:lowercase   lg:grid-cols-#{@test} uppercase"}
+      href="#"></a>
+    """
+
+    expected = ~S"""
+    <a id="testing" class={"potato text-sm uppercase sm:lowercase lg:grid-cols-#{@test}"}
       href="#"></a>
     """
 
@@ -238,6 +266,22 @@ defmodule TailwindFormatterTest do
     expected = ~S"""
     <a class="inline-block rounded-lg bg-green-400 px-3 py-3 text-center text-sm font-semibold text-white shadow-sm transition duration-200 hover:bg-green-500 hover:text-lg hover:shadow-md focus:bg-green-600 focus:shadow-sm focus:ring-4 focus:ring-green-500 focus:ring-opacity-50"
       id="testing"
+      href="#"></a>
+    """
+
+    assert_formatter_output(input, expected)
+  end
+
+  test "placeholding does not change anything outside of class attr" do
+    input = ~S"""
+    <a class={"#{if false, do: "bg-white"} text-sm potato sm:lowercase #{isready?(@check)} uppercase"}
+      id="testing-#{@id}"
+      href="#"></a>
+    """
+
+    expected = ~S"""
+    <a class={"#{if false, do: "bg-white"} #{isready?(@check)} potato text-sm uppercase sm:lowercase"}
+      id="testing-#{@id}"
       href="#"></a>
     """
 


### PR DESCRIPTION
By going with a "placeholder" approach, this simplifies the class parsing.
This PR also supports dynamic classes, i.e. `grid-cols-#{@cols}`

Todo:
- [x] Add more tests (test that placeholding does not interfere with `id=` or any other `#{}` in the html)
- [x] Simplify the `@class` regex now that inline_functions do not have to be accounted for

Closes #13 
Closes #14 