### PR TITLE
Fixed error with more than nine string interpolations

### DIFF
--- a/lib/tailwind_formatter.ex
+++ b/lib/tailwind_formatter.ex
@@ -93,7 +93,7 @@ defmodule TailwindFormatter do
       dynamic_classes
       |> Enum.reduce(contents, fn
         {dynamic_class, index}, contents ->
-          String.replace(contents, dynamic_class, "$#{index}")
+          String.replace(contents, dynamic_class, "$#{index}$")
       end)
 
     {:ok, placeholder_contents, dynamic_classes}
@@ -103,7 +103,7 @@ defmodule TailwindFormatter do
     dynamic_classes
     |> Enum.reduce(sorted_html, fn
       {dynamic_class, index}, html ->
-        String.replace(html, "$#{index}", dynamic_class)
+        String.replace(html, "$#{index}$", dynamic_class)
     end)
   end
 

--- a/test/tailwind_formatter_test.exs
+++ b/test/tailwind_formatter_test.exs
@@ -316,13 +316,13 @@ defmodule TailwindFormatterTest do
     test "missing final quote" do
       input = ~S"""
       <a class={"#{if false, do: "bg-white"} text-sm potato sm:lowercase #{isready?(@check)} uppercase
-        id="testing 
+        id="testing
         href="#"></a>
       """
 
       expected = ~S"""
       <a class={"#{if false, do: "bg-white"} text-sm potato sm:lowercase #{isready?(@check)} uppercase
-        id="testing 
+        id="testing
         href="#"></a>
       """
 
@@ -374,17 +374,39 @@ defmodule TailwindFormatterTest do
     test "missing number tag inline elixir" do
       input = ~S"""
       <a class={"{if false, do: "bg-white"} text-sm potato sm:lowercase uppercase"}
-        id="testing 
+        id="testing
         href="#"></a>
       """
 
       expected = ~S"""
       <a class={"{if false, do: "bg-white"} text-sm potato sm:lowercase uppercase"}
-        id="testing 
+        id="testing
         href="#"></a>
       """
 
       assert_formatter_output(input, expected)
+    end
+
+    test "works with more than nine string interpolations" do
+      input = ~S"""
+      <div text={"foo: #{@foo}"} />
+      <div text={"foo: #{@foo}"} />
+      <div text={"foo: #{@foo}"} />
+      <div text={"foo: #{@foo}"} />
+      <div text={"foo: #{@foo}"} />
+      <div text={"foo: #{@foo}"} />
+      <div text={"foo: #{@foo}"} />
+      <div text={"foo: #{@foo}"} />
+      <div text={"foo: #{@foo}"} />
+      <div text={"foo: #{@foo}"} />
+      <div text={"foo: #{@foo}"} />
+
+      <div text={"bar: #{@bar}"} />
+      <div text={"bar: #{@baz}"} />
+      <div text={"bar: #{@barr}"} />
+      """
+
+      assert_formatter_output(input, input)
     end
   end
 end


### PR DESCRIPTION
When adding placeholders, we need to allow them to be multiple digits long! Closes #21 