### PR TITLE
Also make available in `:test` env

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add `tailwind_formatter` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:tailwind_formatter, "~> 0.3.5", only: :dev, runtime: false}
+    {:tailwind_formatter, "~> 0.3.5", only: [:dev, :test], runtime: false}
   ]
 end
 ```


### PR DESCRIPTION
Many CIs have a `mix format --check-formatted` check, which may have `MIX_ENV=test`.