### PR TITLE
handle local and remote components

### DIFF
--- a/lib/tailwind_formatter.ex
+++ b/lib/tailwind_formatter.ex
@@ -19,7 +19,8 @@ defmodule TailwindFormatter do
     contents
     |> HEExTokenizer.tokenize()
     |> Enum.reduce([contents], fn
-      {:tag, _name, attrs, _meta}, contents ->
+      {elt, _name, attrs, _meta}, contents
+      when elt in [:tag, :local_component, :remote_component] ->
         Enum.reduce(attrs, contents, fn
           {"class", class_attr, _meta}, [remainder | acc] ->
             [attr, remainder] = String.split(remainder, old_classes(class_attr), parts: 2)

--- a/test/tailwind_formatter_test.exs
+++ b/test/tailwind_formatter_test.exs
@@ -499,4 +499,28 @@ defmodule TailwindFormatterTest do
 
     assert_formatter_output(input, expected)
   end
+
+  test "handles local components" do
+    input = """
+    <.img class="text-sm potato sm:lowercase uppercase" />
+    """
+
+    expected = """
+    <.img class="potato text-sm uppercase sm:lowercase" />
+    """
+
+    assert_formatter_output(input, expected)
+  end
+
+  test "handles remote components" do
+    input = """
+    <CP.img class="text-sm potato sm:lowercase uppercase" />
+    """
+
+    expected = """
+    <CP.img class="potato text-sm uppercase sm:lowercase" />
+    """
+
+    assert_formatter_output(input, expected)
+  end
 end


### PR DESCRIPTION
Hey, I made a quick pull request to add support for local and remote components.

i.e.

```tsx
<.link
  navigate={@navigate}
  class="text-sm font-semibold leading-6 text-zinc-900 hover:text-zinc-700"
>
  <HeroIcon.icon name="hero-arrow-left-solid" class="h-3 w-3" />
  <%= render_slot(@inner_block) %>
</.link>
```

It should close #49.