### PR TITLE
docs: Add CI usage instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,27 @@ If some files are not being formatted as expected, double-check the
 `:inputs` option in your `.formatter.exs` to ensure they are being
 matched.
 
+## Usage in CI
+
+To ensure correct sorting, we ask Tailwind to list its configured clases. We then instantiate this
+list at compile-time. Then TailwindFormatter is ready to format, and to check formatting.
+
+In development, all this usually just works due to your existing project setup.
+
+In CI, we have to be a little more explicit. Something like this shown below can be helpful before
+running `--check-formatted` if you're getting CI failures about the ordering of CSS classes.
+
+```yaml
+- name: Generate classes.txt for tailwind
+  run: mix tailwind default
+
+- name: Compile tailwind_formatter plugin
+   run: mix deps.compile tailwind_formatter --force
+
+- name: Check code formatting
+  run: mix format --check-formatted
+```
+
 ## Formatting
 
 The formatter aims to follow a bundle of rules outlined in the [blog post](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier)


### PR DESCRIPTION
What I thought was an issue related to configuration wasn't. :-)

It turned out to be me not running the correct steps for what `tailwind_formatter` needs in CI. The existing documentation was helpful in figuring this out, but I did not find it quite explicit enough to make it easy. Indeed, it wasn't until reading through the code in the `Order` module did I realize what needed to happen.

This PR aims to smooth adoption of your valuable work by adding an explicit section to the README for usage in CI.