### PR TITLE
Handle string objects when reading-in config

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -13,6 +13,7 @@ async function extract(customConfig, buildPath) {
     .getClassList({ includeMetadata: true })
     .flatMap((maybeClass) => {
       if (typeof maybeClass === "string") return maybeClass
+      if (maybeClass instanceof String) return String(maybeClass)
 
       const [className, { modifiers }] = maybeClass
       return [className, ...modifiers.map((m) => `${className}/${m}`)]


### PR DESCRIPTION

I ran into an error when setting up TailwindFormatter in my project (this step https://github.com/100phlecs/tailwind_formatter?tab=readme-ov-file#using-custom-tailwindcss-configuration).

```
$ mix tailwind default

Rebuilding...
<project path>/deps/tailwind_formatter/assets/js/index.js:17
      const [className, { modifiers }] = maybeClass
                          ^

TypeError: Cannot read properties of undefined (reading 'modifiers')
    at <project path>/deps/tailwind_formatter/assets/js/index.js:17:27
    at Array.flatMap (<anonymous>)
    at extract (<project path>/deps/tailwind_formatter/assets/js/index.js:14:6)
** (Mix) `mix tailwind default` exited with 1
```

On inspection it appears the tailwind class list may contain strings, strings with modifiers, OR String objects:

```js
// Example

new String('*')
```

This PR adds a case to handle potential String object tailwind classes during extraction.