### PR TITLE
Fix for DaisyUI

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -13,6 +13,7 @@ async function extract(customConfig, buildPath) {
     .getClassList({ includeMetadata: true })
     .flatMap((maybeClass) => {
       if (typeof maybeClass === "string") return maybeClass
+      if (maybeClass.length === 1) return maybeClass[0]
 
       const [className, { modifiers }] = maybeClass
       return [className, ...modifiers.map((m) => `${className}/${m}`)]


### PR DESCRIPTION
I ran into an using this formatter with [DaisyUI](https://daisyui.com).

`maybeClass` was coming through as `["*"]`. I don't fully understand the internals of DaisyUI, but this to handle that case, and it sorts the DaisyUI classes properly.