### PR TITLE
Update vendored Phoenix LiveView code

### DIFF
--- a/lib/tailwind_formatter/heex_tokenizer.ex
+++ b/lib/tailwind_formatter/heex_tokenizer.ex
@@ -3,11 +3,12 @@ defmodule TailwindFormatter.HEExTokenizer do
   alias TailwindFormatter.PhoenixLiveViewTokenizer, as: Tokenizer
 
   # Taken directly from Phoenix.LiveView.HTMLFormatter
-  # https://github.com/phoenixframework/phoenix_live_view/blob/v0.20.1/lib/phoenix_live_view/html_formatter.ex#L288-L335
+  # https://github.com/phoenixframework/phoenix_live_view/blob/v1.0.10/lib/phoenix_live_view/html_formatter.ex#L277-L304
   @eex_expr [:start_expr, :expr, :end_expr, :middle_expr]
+
   def tokenize(source) do
     {:ok, eex_nodes} = EEx.tokenize(source)
-    {tokens, cont} = Enum.reduce(eex_nodes, {[], :text}, &do_tokenize(&1, &2, source))
+    {tokens, cont} = Enum.reduce(eex_nodes, {[], {:text, :enabled}}, &do_tokenize(&1, &2, source))
     Tokenizer.finalize(tokens, "nofile", cont, source)
   end
 

--- a/lib/tailwind_formatter/phoenix_live_view_html_engine.ex
+++ b/lib/tailwind_formatter/phoenix_live_view_html_engine.ex
@@ -1,16 +1,15 @@
 # Taken directly from Phoenix.LiveView.HTMLEngine
-# https://github.com/phoenixframework/phoenix_live_view/blob/v0.20.1/lib/phoenix_live_view/html_engine.ex#L41-L57
+# https://github.com/phoenixframework/phoenix_live_view/blob/v1.0.10/lib/phoenix_live_view/html_engine.ex#L39-L54
 defmodule TailwindFormatter.PhoenixLiveViewHTMLEngine do
   @moduledoc false
-  def classify_type(":" <> name), do: {:slot, name}
   def classify_type(":inner_block"), do: {:error, "the slot name :inner_block is reserved"}
+  def classify_type(":" <> name), do: {:slot, name}
 
   def classify_type(<<first, _::binary>> = name) when first in ?A..?Z,
     do: {:remote_component, name}
 
-  def classify_type("." <> name),
-    do: {:local_component, name}
-
+  def classify_type("."), do: {:error, "a component name is required after ."}
+  def classify_type("." <> name), do: {:local_component, name}
   def classify_type(name), do: {:tag, name}
 
   for void <- ~w(area base br col hr img input link meta param command keygen source) do

--- a/lib/tailwind_formatter/phoenix_live_view_tokenizer.ex
+++ b/lib/tailwind_formatter/phoenix_live_view_tokenizer.ex
@@ -1,5 +1,5 @@
 # Taken directly from Phoenix.LiveView.Tokenizer
-# https://github.com/phoenixframework/phoenix_live_view/blob/v0.20.1/lib/phoenix_live_view/tokenizer.ex
+# https://github.com/phoenixframework/phoenix_live_view/blob/v1.0.10/lib/phoenix_live_view/tokenizer.ex
 defmodule TailwindFormatter.PhoenixLiveViewTokenizer do
   @moduledoc false
   @space_chars ~c"\s\t\f"
@@ -78,7 +78,7 @@ defmodule TailwindFormatter.PhoenixLiveViewTokenizer do
     %{
       file: file,
       column_offset: indentation + 1,
-      braces: [],
+      braces: :enabled,
       context: [],
       source: source,
       indentation: indentation,
@@ -110,14 +110,14 @@ defmodule TailwindFormatter.PhoenixLiveViewTokenizer do
          {:close, :tag, "section", %{column: 16, line: 1}},
          {:tag, "div", [], %{column: 10, line: 1, closing: :self}},
          {:tag, "section", [], %{column: 1, line: 1}}
-       ], :text}
+       ], {:text, :enabled}}
   """
   def tokenize(text, meta, tokens, cont, state) do
     line = Keyword.get(meta, :line, 1)
     column = Keyword.get(meta, :column, 1)
 
     case cont do
-      :text -> handle_text(text, line, column, [], tokens, state)
+      {:text, braces} -> handle_text(text, line, column, [], tokens, %{state | braces: braces})
       :style -> handle_style(text, line, column, [], tokens, state)
       :script -> handle_script(text, line, column, [], tokens, state)
       {:comment, _, _} -> handle_comment(text, line, column, [], tokens, state)
@@ -157,12 +157,27 @@ defmodule TailwindFormatter.PhoenixLiveViewTokenizer do
     handle_tag_open(rest, line, column + 1, text_to_acc, %{state | context: []})
   end
 
+  defp handle_text("{" <> rest, line, column, buffer, acc, %{braces: :enabled} = state) do
+    text_to_acc = text_to_acc(buffer, acc, line, column, state.context)
+    state = put_in(state.context, [])
+
+    case handle_interpolation(rest, line, column + 1, [], 0, state) do
+      {:ok, value, new_line, new_column, rest} ->
+        acc = [{:body_expr, value, %{line: line, column: column}} | text_to_acc]
+        handle_text(rest, new_line, new_column, [], acc, state)
+
+      {:error, message} ->
+        meta = %{line: line, column: column}
+        raise_syntax_error!(message, meta, state)
+    end
+  end
+
   defp handle_text(<<c::utf8, rest::binary>>, line, column, buffer, acc, state) do
     handle_text(rest, line, column + 1, [char_or_bin(c) | buffer], acc, state)
   end
 
   defp handle_text(<<>>, line, column, buffer, acc, state) do
-    ok(text_to_acc(buffer, acc, line, column, state.context), :text)
+    ok(text_to_acc(buffer, acc, line, column, state.context), {:text, state.braces})
   end
 
   ## handle_doctype
@@ -181,6 +196,14 @@ defmodule TailwindFormatter.PhoenixLiveViewTokenizer do
 
   defp handle_doctype(<<c::utf8, rest::binary>>, line, column, buffer, acc, state) do
     handle_doctype(rest, line, column + 1, [char_or_bin(c) | buffer], acc, state)
+  end
+
+  defp handle_doctype(<<>>, line, column, _buffer, _acc, state) do
+    raise_syntax_error!(
+      "unexpected end of string inside tag",
+      %{line: line, column: column},
+      state
+    )
   end
 
   ## handle_script
@@ -281,7 +304,7 @@ defmodule TailwindFormatter.PhoenixLiveViewTokenizer do
 
         case state.tag_handler.classify_type(name) do
           {:error, message} ->
-            raise_syntax_error!(message, meta, state)
+            raise_syntax_error!(message, %{line: line, column: column}, state)
 
           {type, name} ->
             acc = [{type, name, [], meta} | acc]
@@ -316,7 +339,7 @@ defmodule TailwindFormatter.PhoenixLiveViewTokenizer do
 
           {type, name} ->
             acc = [{:close, type, name, meta} | acc]
-            handle_text(rest, line, new_column + 1, [], acc, state)
+            handle_text(rest, line, new_column + 1, [], acc, pop_braces(state))
         end
 
       {:ok, _, new_column, _} ->
@@ -383,7 +406,7 @@ defmodule TailwindFormatter.PhoenixLiveViewTokenizer do
         handle_style(rest, line, column + 1, [], acc, state)
 
       acc ->
-        handle_text(rest, line, column + 1, [], acc, state)
+        handle_text(rest, line, column + 1, [], acc, push_braces(state))
     end
   end
 
@@ -417,7 +440,7 @@ defmodule TailwindFormatter.PhoenixLiveViewTokenizer do
         <a class={"foo bar #{@class}"}>Text</a>
     """
 
-    raise ParseError, file: state.file, line: line, column: column, description: message
+    raise_syntax_error!(message, %{line: line, column: column}, state)
   end
 
   defp handle_maybe_tag_open_end(text, line, column, acc, state) do
@@ -429,8 +452,19 @@ defmodule TailwindFormatter.PhoenixLiveViewTokenizer do
   defp handle_attribute(text, line, column, acc, state) do
     case handle_attr_name(text, column, []) do
       {:ok, name, new_column, rest} ->
-        acc = put_attr(acc, name, %{line: line, column: column})
-        handle_maybe_attr_value(rest, line, new_column, acc, state)
+        attr_meta = %{line: line, column: column}
+        {text, line, column, value} = handle_maybe_attr_value(rest, line, new_column, state)
+        acc = put_attr(acc, name, attr_meta, value)
+
+        state =
+          if name == "phx-no-curly-interpolation" and state.braces == :enabled and
+               not script_or_style?(acc) do
+            %{state | braces: 0}
+          else
+            state
+          end
+
+        handle_maybe_tag_open_end(text, line, column, acc, state)
 
       {:error, message, column} ->
         meta = %{line: line, column: column}
@@ -438,11 +472,14 @@ defmodule TailwindFormatter.PhoenixLiveViewTokenizer do
     end
   end
 
+  defp script_or_style?([{:tag, name, _, _} | _]) when name in ~w(script style), do: true
+  defp script_or_style?(_), do: false
+
   ## handle_root_attribute
 
   defp handle_root_attribute(text, line, column, acc, state) do
-    case handle_interpolation(text, line, column, [], state) do
-      {:ok, value, new_line, new_column, rest, state} ->
+    case handle_interpolation(text, line, column, [], 0, state) do
+      {:ok, value, new_line, new_column, rest} ->
         meta = %{line: line, column: column}
         acc = put_attr(acc, :root, meta, {:expr, value, meta})
         handle_maybe_tag_open_end(rest, new_line, new_column, acc, state)
@@ -475,60 +512,64 @@ defmodule TailwindFormatter.PhoenixLiveViewTokenizer do
     handle_attr_name(rest, column + 1, [char_or_bin(c) | buffer])
   end
 
+  defp handle_attr_name(<<>>, column, _buffer) do
+    {:error, "unexpected end of string inside tag", column}
+  end
+
   ## handle_maybe_attr_value
 
-  defp handle_maybe_attr_value("\r\n" <> rest, line, _column, acc, state) do
-    handle_maybe_attr_value(rest, line + 1, state.column_offset, acc, state)
+  defp handle_maybe_attr_value("\r\n" <> rest, line, _column, state) do
+    handle_maybe_attr_value(rest, line + 1, state.column_offset, state)
   end
 
-  defp handle_maybe_attr_value("\n" <> rest, line, _column, acc, state) do
-    handle_maybe_attr_value(rest, line + 1, state.column_offset, acc, state)
+  defp handle_maybe_attr_value("\n" <> rest, line, _column, state) do
+    handle_maybe_attr_value(rest, line + 1, state.column_offset, state)
   end
 
-  defp handle_maybe_attr_value(<<c::utf8, rest::binary>>, line, column, acc, state)
+  defp handle_maybe_attr_value(<<c::utf8, rest::binary>>, line, column, state)
        when c in @space_chars do
-    handle_maybe_attr_value(rest, line, column + 1, acc, state)
+    handle_maybe_attr_value(rest, line, column + 1, state)
   end
 
-  defp handle_maybe_attr_value("=" <> rest, line, column, acc, state) do
-    handle_attr_value_begin(rest, line, column + 1, acc, state)
+  defp handle_maybe_attr_value("=" <> rest, line, column, state) do
+    handle_attr_value_begin(rest, line, column + 1, state)
   end
 
-  defp handle_maybe_attr_value(text, line, column, acc, state) do
-    handle_maybe_tag_open_end(text, line, column, acc, state)
+  defp handle_maybe_attr_value(text, line, column, _state) do
+    {text, line, column, nil}
   end
 
   ## handle_attr_value_begin
 
-  defp handle_attr_value_begin("\r\n" <> rest, line, _column, acc, state) do
-    handle_attr_value_begin(rest, line + 1, state.column_offset, acc, state)
+  defp handle_attr_value_begin("\r\n" <> rest, line, _column, state) do
+    handle_attr_value_begin(rest, line + 1, state.column_offset, state)
   end
 
-  defp handle_attr_value_begin("\n" <> rest, line, _column, acc, state) do
-    handle_attr_value_begin(rest, line + 1, state.column_offset, acc, state)
+  defp handle_attr_value_begin("\n" <> rest, line, _column, state) do
+    handle_attr_value_begin(rest, line + 1, state.column_offset, state)
   end
 
-  defp handle_attr_value_begin(<<c::utf8, rest::binary>>, line, column, acc, state)
+  defp handle_attr_value_begin(<<c::utf8, rest::binary>>, line, column, state)
        when c in @space_chars do
-    handle_attr_value_begin(rest, line, column + 1, acc, state)
+    handle_attr_value_begin(rest, line, column + 1, state)
   end
 
-  defp handle_attr_value_begin("\"" <> rest, line, column, acc, state) do
-    handle_attr_value_quote(rest, ?", line, column + 1, [], acc, state)
+  defp handle_attr_value_begin("\"" <> rest, line, column, state) do
+    handle_attr_value_quote(rest, ?", line, column + 1, [], state)
   end
 
-  defp handle_attr_value_begin("'" <> rest, line, column, acc, state) do
-    handle_attr_value_quote(rest, ?', line, column + 1, [], acc, state)
+  defp handle_attr_value_begin("'" <> rest, line, column, state) do
+    handle_attr_value_quote(rest, ?', line, column + 1, [], state)
   end
 
-  defp handle_attr_value_begin("{" <> rest, line, column, acc, state) do
-    handle_attr_value_as_expr(rest, line, column + 1, acc, state)
+  defp handle_attr_value_begin("{" <> rest, line, column, state) do
+    handle_attr_value_as_expr(rest, line, column + 1, state)
   end
 
-  defp handle_attr_value_begin(_text, line, column, _acc, state) do
+  defp handle_attr_value_begin(_text, line, column, state) do
     message =
       "invalid attribute value after `=`. Expected either a value between quotes " <>
-        "(such as \"value\" or \'value\') or an Elixir expression between curly brackets (such as `{expr}`)"
+        "(such as \"value\" or \'value\') or an Elixir expression between curly braces (such as `{expr}`)"
 
     meta = %{line: line, column: column}
     raise_syntax_error!(message, meta, state)
@@ -536,27 +577,26 @@ defmodule TailwindFormatter.PhoenixLiveViewTokenizer do
 
   ## handle_attr_value_quote
 
-  defp handle_attr_value_quote("\r\n" <> rest, delim, line, _column, buffer, acc, state) do
+  defp handle_attr_value_quote("\r\n" <> rest, delim, line, _column, buffer, state) do
     column = state.column_offset
-    handle_attr_value_quote(rest, delim, line + 1, column, ["\r\n" | buffer], acc, state)
+    handle_attr_value_quote(rest, delim, line + 1, column, ["\r\n" | buffer], state)
   end
 
-  defp handle_attr_value_quote("\n" <> rest, delim, line, _column, buffer, acc, state) do
+  defp handle_attr_value_quote("\n" <> rest, delim, line, _column, buffer, state) do
     column = state.column_offset
-    handle_attr_value_quote(rest, delim, line + 1, column, ["\n" | buffer], acc, state)
+    handle_attr_value_quote(rest, delim, line + 1, column, ["\n" | buffer], state)
   end
 
-  defp handle_attr_value_quote(<<delim, rest::binary>>, delim, line, column, buffer, acc, state) do
+  defp handle_attr_value_quote(<<delim, rest::binary>>, delim, line, column, buffer, _state) do
     value = buffer_to_string(buffer)
-    acc = put_attr_value(acc, {:string, value, %{delimiter: delim}})
-    handle_maybe_tag_open_end(rest, line, column + 1, acc, state)
+    {rest, line, column + 1, {:string, value, %{delimiter: delim}}}
   end
 
-  defp handle_attr_value_quote(<<c::utf8, rest::binary>>, delim, line, column, buffer, acc, state) do
-    handle_attr_value_quote(rest, delim, line, column + 1, [char_or_bin(c) | buffer], acc, state)
+  defp handle_attr_value_quote(<<c::utf8, rest::binary>>, delim, line, column, buffer, state) do
+    handle_attr_value_quote(rest, delim, line, column + 1, [char_or_bin(c) | buffer], state)
   end
 
-  defp handle_attr_value_quote(<<>>, delim, line, column, _buffer, _acc, state) do
+  defp handle_attr_value_quote(<<>>, delim, line, column, _buffer, state) do
     message = """
     expected closing `#{<<delim>>}` for attribute value
 
@@ -581,11 +621,10 @@ defmodule TailwindFormatter.PhoenixLiveViewTokenizer do
 
   ## handle_attr_value_as_expr
 
-  defp handle_attr_value_as_expr(text, line, column, acc, %{braces: []} = state) do
-    case handle_interpolation(text, line, column, [], state) do
-      {:ok, value, new_line, new_column, rest, state} ->
-        acc = put_attr_value(acc, {:expr, value, %{line: line, column: column}})
-        handle_maybe_tag_open_end(rest, new_line, new_column, acc, state)
+  defp handle_attr_value_as_expr(text, line, column, state) do
+    case handle_interpolation(text, line, column, [], 0, state) do
+      {:ok, value, new_line, new_column, rest} ->
+        {rest, new_line, new_column, {:expr, value, %{line: line, column: column}}}
 
       {:error, message} ->
         # We do column - 1 to point to the opening {
@@ -596,43 +635,47 @@ defmodule TailwindFormatter.PhoenixLiveViewTokenizer do
 
   ## handle_interpolation
 
-  defp handle_interpolation("\r\n" <> rest, line, _column, buffer, state) do
-    handle_interpolation(rest, line + 1, state.column_offset, ["\r\n" | buffer], state)
+  defp handle_interpolation("\r\n" <> rest, line, _column, buffer, braces, state) do
+    handle_interpolation(rest, line + 1, state.column_offset, ["\r\n" | buffer], braces, state)
   end
 
-  defp handle_interpolation("\n" <> rest, line, _column, buffer, state) do
-    handle_interpolation(rest, line + 1, state.column_offset, ["\n" | buffer], state)
+  defp handle_interpolation("\n" <> rest, line, _column, buffer, braces, state) do
+    handle_interpolation(rest, line + 1, state.column_offset, ["\n" | buffer], braces, state)
   end
 
-  defp handle_interpolation("}" <> rest, line, column, buffer, %{braces: []} = state) do
+  defp handle_interpolation("}" <> rest, line, column, buffer, 0, _state) do
     value = buffer_to_string(buffer)
-    {:ok, value, line, column + 1, rest, state}
+    {:ok, value, line, column + 1, rest}
   end
 
-  defp handle_interpolation(~S(\}) <> rest, line, column, buffer, state) do
-    handle_interpolation(rest, line, column + 2, [~S(\}) | buffer], state)
+  defp handle_interpolation(~S(\}) <> rest, line, column, buffer, braces, state) do
+    handle_interpolation(rest, line, column + 2, [~S(\}) | buffer], braces, state)
   end
 
-  defp handle_interpolation(~S(\{) <> rest, line, column, buffer, state) do
-    handle_interpolation(rest, line, column + 2, [~S(\{) | buffer], state)
+  defp handle_interpolation(~S(\{) <> rest, line, column, buffer, braces, state) do
+    handle_interpolation(rest, line, column + 2, [~S(\{) | buffer], braces, state)
   end
 
-  defp handle_interpolation("}" <> rest, line, column, buffer, state) do
-    {_pos, state} = pop_brace(state)
-    handle_interpolation(rest, line, column + 1, ["}" | buffer], state)
+  defp handle_interpolation("}" <> rest, line, column, buffer, braces, state) do
+    handle_interpolation(rest, line, column + 1, ["}" | buffer], braces - 1, state)
   end
 
-  defp handle_interpolation("{" <> rest, line, column, buffer, state) do
-    state = push_brace(state, {line, column})
-    handle_interpolation(rest, line, column + 1, ["{" | buffer], state)
+  defp handle_interpolation("{" <> rest, line, column, buffer, braces, state) do
+    handle_interpolation(rest, line, column + 1, ["{" | buffer], braces + 1, state)
   end
 
-  defp handle_interpolation(<<c::utf8, rest::binary>>, line, column, buffer, state) do
-    handle_interpolation(rest, line, column + 1, [char_or_bin(c) | buffer], state)
+  defp handle_interpolation(<<c::utf8, rest::binary>>, line, column, buffer, braces, state) do
+    handle_interpolation(rest, line, column + 1, [char_or_bin(c) | buffer], braces, state)
   end
 
-  defp handle_interpolation(<<>>, _line, _column, _buffer, _state) do
-    {:error, "expected closing `}` for expression"}
+  defp handle_interpolation(<<>>, _line, _column, _buffer, _braces, _state) do
+    {:error,
+     """
+     expected closing `}` for expression
+
+     In case you don't want `{` to begin a new interpolation, \
+     you may write it using `&lbrace;` or using `<%= "{" %>`\
+     """}
   end
 
   ## helpers
@@ -668,12 +711,14 @@ defmodule TailwindFormatter.PhoenixLiveViewTokenizer do
   defp trim_context([:comment_end, :comment_start | [_ | _] = rest]), do: trim_context(rest)
   defp trim_context(rest), do: Enum.reverse(rest)
 
-  defp put_attr([{type, name, attrs, meta} | acc], attr, attr_meta, value \\ nil) do
-    attrs = [{attr, value, attr_meta} | attrs]
-    [{type, name, attrs, meta} | acc]
-  end
+  defp push_braces(%{braces: :enabled} = state), do: state
+  defp push_braces(%{braces: braces} = state), do: %{state | braces: braces + 1}
 
-  defp put_attr_value([{type, name, [{attr, _value, attr_meta} | attrs], meta} | acc], value) do
+  defp pop_braces(%{braces: :enabled} = state), do: state
+  defp pop_braces(%{braces: 1} = state), do: %{state | braces: :enabled}
+  defp pop_braces(%{braces: braces} = state), do: %{state | braces: braces - 1}
+
+  defp put_attr([{type, name, attrs, meta} | acc], attr, attr_meta, value) do
     attrs = [{attr, value, attr_meta} | attrs]
     [{type, name, attrs, meta} | acc]
   end
@@ -690,14 +735,6 @@ defmodule TailwindFormatter.PhoenixLiveViewTokenizer do
       end
 
     [{type, name, attrs, meta} | acc]
-  end
-
-  defp push_brace(state, pos) do
-    %{state | braces: [pos | state.braces]}
-  end
-
-  defp pop_brace(%{braces: [pos | braces]} = state) do
-    {pos, %{state | braces: braces}}
   end
 
   defp strip_text_token_fully(tokens) do


### PR DESCRIPTION
Closes #68.

The Phoenix LiveView team declined to accept https://github.com/phoenixframework/phoenix_live_view/pull/3778, which, I was hoping, would allow us to remove these vendored code. They instead proposed a different solution: https://github.com/phoenixframework/phoenix_live_view/pull/3781. This will be available in Phoenix LiveView v1.1. Until then, updating the vendored code would allow users who are still on Phoenix LiveView 1.0 or earlier to use TailwindFormatter.