### PR TITLE
Bug: Reordering breaks 'before' + nested class selector

### DIFF
--- a/test/tailwind_formatter_test.exs
+++ b/test/tailwind_formatter_test.exs
@@ -560,4 +560,16 @@ defmodule TailwindFormatterTest do
 
     assert_formatter_output(input, expected)
   end
+
+  test "preserves order of before modifier after nested arbitrary selector" do
+    input = """
+    <div class="[&_.nested]:before:content-['hello_']"><span class="nested">world</span></div>
+    """
+
+    expected = """
+    <div class="[&_.nested]:before:content-['hello_']"><span class="nested">world</span></div>
+    """
+
+    assert_formatter_output(input, expected)
+  end
 end


### PR DESCRIPTION
Example: https://play.tailwindcss.com/jpSQGTUxkw

Given
```html
<div class="[&_.nested]:before:content-['hello_']"><span class="nested">world</span></div>
```

I expect to see
<img width="92" alt="image" src="https://github.com/user-attachments/assets/5a860bd0-55ea-465f-9ce2-57aeb76e66e4" />

But after formatting I see
<img width="92" alt="image" src="https://github.com/user-attachments/assets/7475ef0e-1755-4879-b0e2-9d660e835144" />

Because the class name was formatted (`before:` was moved to front):
```html
<div class="before:[&_.nested]:content-['hello_']"><span class="nested">world</span></div>
```
