### PR TITLE
Add failing double space tests

### DIFF
--- a/test/tailwind_formatter_test.exs
+++ b/test/tailwind_formatter_test.exs
@@ -560,4 +560,32 @@ defmodule TailwindFormatterTest do
 
     assert_formatter_output(input, expected)
   end
+
+  test "double space inserted by formatter into Enum.join/3" do
+    input = """
+    <.div class={["flex p-1", some_func("focus-within:border-neutral", @var)] |> Enum.join(" ")}>
+    </.div>
+    """
+
+    expected = """
+    <.div class={["flex p-1", some_func("focus-within:border-neutral", @var)] |> Enum.join(" ")}>
+    </.div>
+    """
+
+    assert_formatter_output(input, expected)
+  end
+
+  test "formating works for space in constant" do
+    input = """
+    {space = " "}
+    <.div class={["flex p-1", Enum.join(some_func("focus-within:border-neutral", @var), space)]}></div>
+    """
+
+    expected = """
+    {space = " "}
+    <.div class={["flex p-1", Enum.join(some_func("focus-within:border-neutral", @var), space)]}></div>
+    """
+
+    assert_formatter_output(input, expected)
+  end
 end

--- a/test/tailwind_formatter_test.exs
+++ b/test/tailwind_formatter_test.exs
@@ -563,27 +563,26 @@ defmodule TailwindFormatterTest do
 
   test "double space inserted by formatter into Enum.join/3" do
     input = """
-    <.div class={["flex p-1", some_func("focus-within:border-neutral", @var)] |> Enum.join(" ")}>
-    </.div>
+    <.div class={Enum.join([], " ")}></.div>
     """
 
     expected = """
-    <.div class={["flex p-1", some_func("focus-within:border-neutral", @var)] |> Enum.join(" ")}>
-    </.div>
+    <.div class={Enum.join([], " ")}></.div>
     """
 
     assert_formatter_output(input, expected)
   end
 
-  test "formating works for space in constant" do
+
+  test "formatting works for space in constant" do
     input = """
     {space = " "}
-    <.div class={["flex p-1", Enum.join(some_func("focus-within:border-neutral", @var), space)]}></div>
+    <.div class={Enum.join([], space)}></.div>
     """
 
     expected = """
     {space = " "}
-    <.div class={["flex p-1", Enum.join(some_func("focus-within:border-neutral", @var), space)]}></div>
+    <.div class={Enum.join([], space)}></.div>
     """
 
     assert_formatter_output(input, expected)


### PR DESCRIPTION
## Related to #74 


This is the original code that was showing the error
```elixir
<div>
  <.svelte
    class={
      [
        "border-base-300 h-full max-w-full rounded-md border p-1",
        dyn_apply("focus-within:border-neutral", @editable)
      ]
      |> Enum.join(" ")
    }
    name="Markdown"
    socket={@socket}
    props={
      %{
        id: "some_id"
      }
    }
  >
  </.svelte>
</div>
```

### In short, this is what is caused by this issue
```diff
- Enum.join("  ")
+ Enum.join("   ")
```

### See test output 

```bash
Running ExUnit with seed: 262753, max_cases: 44

.........

  1) test double space inserted by formatter into Enum.join/3 (TailwindFormatterTest)
     test/tailwind_formatter_test.exs:564
     Assertion with == failed
     code:  assert first_pass == expected
     left:  "<.div class={Enum.join([], \"  \")}></.div>\n"
     right: "<.div class={Enum.join([], \" \")}></.div>\n"
     stacktrace:
       test/tailwind_formatter_test.exs:9: TailwindFormatterTest.assert_formatter_output/3
       test/tailwind_formatter_test.exs:573: (test)

..........................
Finished in 0.1 seconds (0.00s async, 0.1s sync)
36 tests, 1 failure
```